### PR TITLE
Feat: Add automation scripts for AWS Cloudtrail log management and setup (#1)

### DIFF
--- a/Stratus-red-team/Automate_logs/automate_attack_logs.sh
+++ b/Stratus-red-team/Automate_logs/automate_attack_logs.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+# 사용자 입력을 통해 계정 정보 받기
+echo "공격자 계정 이름을 입력하세요:"
+read ACCOUNT
+echo "AWS Access Key를 입력하세요:"
+read ACCESS_KEY
+echo "AWS Secret Key를 입력하세요:"
+read -s SECRET_KEY  # Secret Key는 보이지 않게 입력받기
+
+# 로그 저장 경로 설정
+SCENARIO="$1"  # 첫 번째 인자로 시나리오 이름을 입력받음
+BASE_DIR="/Users/taeyangkim/Desktop/Coding/Project/AWS" # 올바른 프로젝트 디렉토리 설정
+LOG_DIR="$BASE_DIR/scenarios/Credential_Access/$SCENARIO/Attack_logs"
+WARMUP_LOG_DIR="$LOG_DIR/Warmup_logs"
+DETONATE_LOG_DIR="$LOG_DIR/Detonate_logs"
+
+# 로그 디렉토리 생성
+mkdir -p "$WARMUP_LOG_DIR"
+mkdir -p "$DETONATE_LOG_DIR"
+echo "Warmup 로그 저장 경로: $WARMUP_LOG_DIR"
+echo "Detonate 로그 저장 경로: $DETONATE_LOG_DIR"
+
+# macOS와 리눅스의 date 명령어 차이 해결
+add_minutes() {
+    date -u -v +"$1"M +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+# 현재 시간에서 1시간 전
+START_TIME=$(date -u -v -60M +"%Y-%m-%dT%H:%M:%SZ")
+echo "로그 수집 시작 시간 (1시간 전): $START_TIME"
+
+# 현재 시간에서 3시간 후
+END_TIME=$(date -u -v +180M +"%Y-%m-%dT%H:%M:%SZ")
+echo "로그 수집 종료 시간 (3시간 후): $END_TIME"
+
+# AWS CLI 프로파일 구성
+aws configure set aws_access_key_id $ACCESS_KEY --profile $ACCOUNT
+aws configure set aws_secret_access_key $SECRET_KEY --profile $ACCOUNT
+aws configure set region us-east-1 --profile $ACCOUNT
+
+# AWS 프로파일 및 리전 설정
+export AWS_PROFILE=$ACCOUNT
+export AWS_REGION=us-east-1
+
+# 인증 확인
+aws sts get-caller-identity --profile $ACCOUNT > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "AWS 인증 실패: $ACCOUNT. 스킵합니다."
+    exit 1
+fi
+
+# Warmup 수행
+echo "Warming up for scenario $SCENARIO as $ACCOUNT"
+warmup_output=$(stratus warmup $SCENARIO 2>&1)
+if [ $? -ne 0 ]; then
+    echo "Warmup 실패: $ACCOUNT. 스킵합니다."
+    echo "$warmup_output"  # 에러 메시지 출력
+    exit 1
+fi
+
+# Warmup 로그 수집
+WARMUP_LOG_FILE="$WARMUP_LOG_DIR/${ACCOUNT}_warmup_log.json"
+echo "CloudTrail Warmup 로그 수집"
+aws cloudtrail lookup-events \
+    --lookup-attributes AttributeKey=Username,AttributeValue=$ACCOUNT \
+    --start-time "$START_TIME" \
+    --end-time "$END_TIME" \
+    --output json > "$WARMUP_LOG_FILE"
+
+if [ -s "$WARMUP_LOG_FILE" ]; then
+    echo "Warmup 로그 파일 저장됨: $WARMUP_LOG_FILE"
+else
+    echo "Warmup 로그 파일 생성 안됨"
+fi
+
+# Detonate 수행
+echo "Detonating attack scenario $SCENARIO as $ACCOUNT"
+detonate_output=$(stratus detonate $SCENARIO 2>&1)
+if [ $? -ne 0 ]; then
+    echo "Detonation 실패: $ACCOUNT. 스킵합니다."
+    echo "$detonate_output"  # 에러 메시지 출력
+    exit 1
+fi
+
+# Detonate 로그 수집
+DETONATE_LOG_FILE="$DETONATE_LOG_DIR/${ACCOUNT}_detonate_log.json"
+echo "CloudTrail Detonate 로그 수집"
+aws cloudtrail lookup-events \
+    --lookup-attributes AttributeKey=Username,AttributeValue=$ACCOUNT \
+    --start-time "$START_TIME" \
+    --end-time "$END_TIME" \
+    --output json > "$DETONATE_LOG_FILE"
+
+if [ -s "$DETONATE_LOG_FILE" ]; then
+    echo "Detonate 로그 파일 저장됨: $DETONATE_LOG_FILE"
+else
+    echo "Detonate 로그 파일 생성 안됨"
+fi
+
+# Cleanup 수행
+echo "Cleaning up resources for $SCENARIO as $ACCOUNT"
+stratus cleanup $SCENARIO --force
+if [ $? -ne 0 ]; then
+    echo "Cleanup 실패: $ACCOUNT."
+fi
+
+echo "Completed cleanup for $ACCOUNT"
+echo "Warmup 및 Detonate 로그 수집 및 Cleanup 완료"

--- a/Stratus-red-team/Check_scripts/check_accounts.sh
+++ b/Stratus-red-team/Check_scripts/check_accounts.sh
@@ -1,0 +1,16 @@
+# accounts.sh 스크립트 예시
+#!/bin/bash
+
+# 모든 계정의 프로파일 배열
+PROFILES=("attack_user" "attack_user_02" "attack_user_03" "attack_user_04" "attack_user_05" "attack_user_06" "attack_user_07" "attack_user_08" "attack_user_09" "attack_user_10")
+
+for profile in "${PROFILES[@]}"; do
+    echo "Checking AWS authentication for profile: $profile"
+    aws sts get-caller-identity --profile $profile
+    if [ $? -eq 0 ]; then
+        echo "$profile authentication successful."
+    else
+        echo "$profile authentication failed."
+    fi
+    echo "---------------------------"
+done

--- a/Stratus-red-team/Check_scripts/check_iam_policies.sh
+++ b/Stratus-red-team/Check_scripts/check_iam_policies.sh
@@ -1,0 +1,11 @@
+# check_iam_policies.sh 스크립트 예시
+#!/bin/bash
+
+# 계정별 프로파일 배열
+PROFILES=("attack_user" "attack_user_02" "attack_user_03" "attack_user_04" "attack_user_05" "attack_user_06" "attack_user_07" "attack_user_08" "attack_user_09" "attack_user_10")
+
+for profile in "${PROFILES[@]}"; do
+    echo "Checking IAM policies for profile: $profile"
+    aws iam list-attached-user-policies --user-name $profile --profile $profile
+    echo "---------------------------"
+done

--- a/Stratus-red-team/IAM_roles/create_attack_iam.sh
+++ b/Stratus-red-team/IAM_roles/create_attack_iam.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# 사용자 이름을 명령줄 인수로 받음
+if [ -z "$1" ]; then
+  echo "사용자 이름을 입력하세요."
+  echo "사용법: $0 <사용자이름>"
+  exit 1
+fi
+
+USER_NAME="$1"
+
+# 정책 배열을 명령줄 인수로 전달받거나 기본값 설정
+POLICIES=("arn:aws:iam::aws:policy/AdministratorAccess")
+
+# IAM 사용자 생성
+echo "IAM 사용자 $USER_NAME 생성 중..."
+aws iam create-user --user-name $USER_NAME
+
+# 사용자에게 관리자 권한 또는 지정된 정책 연결
+for POLICY_ARN in "${POLICIES[@]}"; do
+  echo "사용자 $USER_NAME에 정책 $POLICY_ARN 연결 중..."
+  aws iam attach-user-policy --user-name $USER_NAME --policy-arn $POLICY_ARN
+done
+
+# 사용자의 액세스 키 생성 및 저장
+ACCESS_KEYS=$(aws iam create-access-key --user-name $USER_NAME)
+
+# 액세스 키와 비밀 액세스 키 추출
+ACCESS_KEY_ID=$(echo $ACCESS_KEYS | jq -r '.AccessKey.AccessKeyId')
+SECRET_ACCESS_KEY=$(echo $ACCESS_KEYS | jq -r '.AccessKey.SecretAccessKey')
+
+# 액세스 키 정보를 출력하여 aws configure에서 사용
+echo "ACCESS_KEY_ID: $ACCESS_KEY_ID"
+echo "SECRET_ACCESS_KEY: $SECRET_ACCESS_KEY"

--- a/Stratus-red-team/IAM_roles/create_normal_iam.sh
+++ b/Stratus-red-team/IAM_roles/create_normal_iam.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# 정책 배열 설정 (필요에 따라 다른 정책 추가 가능)
+POLICIES=("arn:aws:iam::aws:policy/AdministratorAccess")
+
+# 사용자 생성 및 정책 연결 함수
+create_user_with_policies() {
+  USER_NAME="$1"
+  
+  # IAM 사용자 생성
+  echo "IAM 사용자 $USER_NAME 생성 중..."
+  aws iam create-user --user-name $USER_NAME
+  
+  # 사용자에게 정책 연결
+  for POLICY_ARN in "${POLICIES[@]}"; do
+    echo "사용자 $USER_NAME에 정책 $POLICY_ARN 연결 중..."
+    aws iam attach-user-policy --user-name $USER_NAME --policy-arn $POLICY_ARN
+  done
+
+  # 사용자의 액세스 키 생성 및 저장
+  ACCESS_KEYS=$(aws iam create-access-key --user-name $USER_NAME)
+
+  # 액세스 키와 비밀 액세스 키 추출
+  ACCESS_KEY_ID=$(echo $ACCESS_KEYS | jq -r '.AccessKey.AccessKeyId')
+  SECRET_ACCESS_KEY=$(echo $ACCESS_KEYS | jq -r '.AccessKey.SecretAccessKey')
+
+  # 액세스 키 정보를 출력
+  echo "ACCESS_KEY_ID: $ACCESS_KEY_ID"
+  echo "SECRET_ACCESS_KEY: $SECRET_ACCESS_KEY"
+}
+
+# IAM 사용자 20명 생성
+for i in {01..20}; do
+  USER_NAME="normal-user-${i}"
+  create_user_with_policies "$USER_NAME"
+done
+
+echo "모든 정상 로그용 IAM 사용자 생성 완료."
+#!/bin/bash
+
+# 로그 파일 설정
+LOG_FILE="create_iam_users.log"
+touch $LOG_FILE
+
+# 정책 배열 설정 (필요에 따라 다른 정책 추가 가능)
+POLICIES=("arn:aws:iam::aws:policy/AdministratorAccess")
+
+# 사용자 생성 및 정책 연결 함수
+create_user_with_policies() {
+  USER_NAME="$1"
+  
+  # IAM 사용자 생성
+  echo "IAM 사용자 $USER_NAME 생성 중..." | tee -a $LOG_FILE
+  aws iam create-user --user-name $USER_NAME 2>&1 | tee -a $LOG_FILE
+  
+  # 사용자에게 정책 연결
+  for POLICY_ARN in "${POLICIES[@]}"; do
+    echo "사용자 $USER_NAME에 정책 $POLICY_ARN 연결 중..." | tee -a $LOG_FILE
+    aws iam attach-user-policy --user-name $USER_NAME --policy-arn $POLICY_ARN 2>&1 | tee -a $LOG_FILE
+  done
+
+  # 사용자의 액세스 키 생성 및 저장
+  ACCESS_KEYS=$(aws iam create-access-key --user-name $USER_NAME 2>&1 | tee -a $LOG_FILE)
+
+  # 액세스 키와 비밀 액세스 키 추출
+  ACCESS_KEY_ID=$(echo $ACCESS_KEYS | jq -r '.AccessKey.AccessKeyId')
+  SECRET_ACCESS_KEY=$(echo $ACCESS_KEYS | jq -r '.AccessKey.SecretAccessKey')
+
+  # 액세스 키 정보를 출력 및 로그에 저장
+  echo "ACCESS_KEY_ID: $ACCESS_KEY_ID" | tee -a $LOG_FILE
+  echo "SECRET_ACCESS_KEY: $SECRET_ACCESS_KEY" | tee -a $LOG_FILE
+}
+
+# IAM 사용자 20명 생성
+for i in {01..20}; do
+  USER_NAME="normal-user-${i}"
+  create_user_with_policies "$USER_NAME"
+  
+  # 사용자 생성 후 2초 대기
+  sleep 2
+done
+
+echo "모든 정상 로그용 IAM 사용자 생성 완료." | tee -a $LOG_FILE

--- a/Stratus-red-team/IAM_roles/register_aws_profiles.sh
+++ b/Stratus-red-team/IAM_roles/register_aws_profiles.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# 정상 계정 정보 파일 경로 설정 (절대 경로로 수정)
+USER_CSV="/Users/taeyangkim/Desktop/normal_users.csv"
+
+# CSV 파일이 존재하는지 확인
+if [ ! -f "$USER_CSV" ]; then
+    echo "CSV 파일을 찾을 수 없습니다: $USER_CSV"
+    exit 1
+fi
+
+# CSV 파일을 읽어서 각 사용자 프로파일 등록
+while IFS=, read -r UserName AccessKeyId SecretAccessKey
+do
+    # 헤더 라인은 무시
+    if [ "$UserName" == "UserName" ]; then
+        continue
+    fi
+
+    # AWS CLI 프로파일 설정
+    echo "프로파일 설정 중: $UserName"
+    aws configure set aws_access_key_id $AccessKeyId --profile $UserName
+    aws configure set aws_secret_access_key $SecretAccessKey --profile $UserName
+    aws configure set region us-east-1 --profile $UserName
+
+    # 설정 확인
+    echo "AWS CLI 프로파일이 설정되었습니다: $UserName"
+
+done < "$USER_CSV"
+
+echo "모든 정상 계정에 대한 AWS CLI 프로파일 등록이 완료되었습니다."


### PR DESCRIPTION
### Summary of Changes
- Added automation scripts for AWS Cloudtrail log management, including:
  - `automate_attack_logs.sh`: Automates the creation of attack logs.
  - `check_accounts.sh`: Checks AWS accounts for compliance with security standards.
  - `create_attack_iam.sh`: Sets up IAM roles for testing attack scenarios.

### How to Test
1. Set up your AWS profiles using `register_aws_profiles.sh`.
2. Run `automate_attack_logs.sh` to generate sample attack logs.
3. Verify that logs are created and stored in the designated S3 bucket.

### Additional Notes
- IAM role cleanup scripts are not included in this PR and will be added later.
- Ensure that AWS CLI is configured correctly before running the scripts.

### Related Issues
- Resolves #42: Implement automation for CloudTrail log generation.